### PR TITLE
Add image release workflow

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,2 +1,0 @@
-enabled:
-  - cla

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches:
       - main
@@ -8,11 +8,12 @@ on:
 
 jobs:
   checks:
+    if: 'false'
     name: Tests + Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-       
+      - uses: actions/checkout@v3
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -22,16 +23,15 @@ jobs:
           components: clippy, rustfmt
 
       - name: Cargo Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
             ${{ runner.os }}-cargo
-
       - name: Cargo Target Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-cargo-target
 
       - name: Install wasmtime-cli
-        run: cargo install wasmtime-cli
+        run: cargo install --version 0.35.3 wasmtime-cli
 
       - name: Install cargo-wasi
         run: cargo install cargo-wasi
@@ -51,5 +51,36 @@ jobs:
       - name: Lint
         run: make fmt
 
+  image:
+    runs-on: ubuntu-latest
 
-  
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v2
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v3
+        id: docker_meta
+        with:
+          images: ghcr.io/suborbital/javy
+          tags: |
+            type=match,pattern=suborbital-(v.*)
+          flavor: |
+            latest=auto
+
+      - name: Build and push javy image
+        uses: docker/build-push-action@v3
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ startsWith(github.ref, 'refs/tags/suborbital-v') }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,11 +6,11 @@ on:
       - created
 
 jobs:
-  compile_core: 
+  compile_core:
     name: Compile Core
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name : Install Rust
         uses: actions-rs/toolchain@v1
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload core binary to artifacts
         uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: engine
           path: target/wasm32-wasi/release/javy_core.wasm
 
@@ -33,7 +33,7 @@ jobs:
     name: Compile CLI
     needs:  compile_core
     runs-on: ${{ matrix.os }}
-    strategy: 
+    strategy:
       matrix:
         include:
           - name: linux
@@ -53,7 +53,7 @@ jobs:
             shasum_cmd: sha256sum
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v2
         with:
@@ -61,7 +61,7 @@ jobs:
           path: crates/cli/
 
       - name: ls
-        run: ls -R 
+        run: ls -R
         working-directory: crates/cli/
 
       - name : Install Rust
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload assets to artifacts
         uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: ${{ matrix.asset_name }}.gz
           path: ${{ matrix.asset_name }}.gz
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload asset hash to artifacts
         uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: ${{ matrix.asset_name }}.gz.sha256
           path: ${{ matrix.asset_name }}.gz.sha256
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM rust:1.56.1-slim-bullseye as builder
+WORKDIR /root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+    cmake \
+    curl \
+    libssl-dev \
+    pkg-config \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+RUN rustup target install wasm32-wasi
+
+COPY Cargo.* .
+COPY Makefile Makefile
+COPY ./crates ./crates
+RUN make cli
+
+FROM debian:bullseye-slim
+COPY --from=builder /root/target/release/javy /usr/local/bin


### PR DESCRIPTION
Adds a `release` job to the ci workflow that builds and pushes javy images to ghcr.

Also removes the probot yaml as we won't and don't want to run this on that fork.
